### PR TITLE
styles: use dvh for body height to improve mobile browser usage

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -144,7 +144,7 @@
 }
 
 body {
-    height: 100vh;
+    height: 100dvh;
     margin: 0;
     padding: 0;
     font-family: "Roboto", sans-serif;


### PR DESCRIPTION
On mobile browsers (eg. Safari) the viewport can be partially blocked by the browser nav bar. Using dvh ensures the page is rendered only in the visible portion.